### PR TITLE
Add comment like functionality with API endpoints

### DIFF
--- a/TestProofs/API/posts_media/comment_get_likes.mp4
+++ b/TestProofs/API/posts_media/comment_get_likes.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e78dd2f7dd0c29308ba717b2226340ae2aabfa569f374ccee8ccea7f20e0a949
+size 10959735

--- a/TestProofs/API/posts_media/comment_like_dislike.mp4
+++ b/TestProofs/API/posts_media/comment_like_dislike.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3686ced3fcde8177aa7c1cefc3a9455f5583c2d044512c721c9916d20c74841
+size 8540690

--- a/backend/src/api/posts/get_comment_likes.php
+++ b/backend/src/api/posts/get_comment_likes.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Get Comment Likes API Endpoint
+ * 
+ * Retrieves list of users who liked a comment
+ * Endpoint: GET /api/posts/get_comment_likes
+ */
+
+// Set headers
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+// Handle preflight request
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    exit(0);
+}
+
+// Only allow GET requests
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed']);
+    exit();
+}
+
+// Require authentication
+$requireAuth = true;
+
+// Get database connection
+$Database = require_once dirname(dirname(dirname(__FILE__))) . '/db_handler/connection.php';
+
+// Include authentication middleware
+require_once dirname(dirname(__FILE__)) . '/auth/auth_middleware.php';
+
+// Get parameters
+$commentId = isset($_GET['comment_id']) ? (int)$_GET['comment_id'] : null;
+$page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 20;
+
+// Validate comment ID
+if (!$commentId) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Comment ID is required']);
+    exit();
+}
+
+// Validate pagination parameters
+if ($page < 1) {
+    $page = 1;
+}
+if ($limit < 1 || $limit > 50) {
+    $limit = 20;
+}
+
+// Calculate offset
+$offset = ($page - 1) * $limit;
+$userId = $authUser['user_id'];
+
+// Check if comment exists and user can view it (through post privacy)
+$checkSql = "
+    SELECT c.comment_id, c.post_id, p.user_id as post_user_id, p.privacy_level
+    FROM comments c
+    INNER JOIN posts p ON c.post_id = p.post_id
+    INNER JOIN users u ON p.user_id = u.user_id
+    LEFT JOIN friendships f1 ON (f1.user_id_1 = ? AND f1.user_id_2 = p.user_id AND f1.status = 'accepted')
+    LEFT JOIN friendships f2 ON (f2.user_id_2 = ? AND f2.user_id_1 = p.user_id AND f2.status = 'accepted')
+    WHERE c.comment_id = ?
+    AND u.account_status = 'active'
+    AND (
+        p.user_id = ? OR  -- User's own posts
+        p.privacy_level = 'public' OR  -- Public posts
+        (p.privacy_level = 'friends' AND (f1.friendship_id IS NOT NULL OR f2.friendship_id IS NOT NULL))  -- Friends-only posts from accepted friends
+    )
+";
+
+$comment = $Database->query($checkSql, [$userId, $userId, $commentId, $userId]);
+
+if ($comment === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database error']);
+    exit();
+}
+
+if (empty($comment)) {
+    http_response_code(404);
+    echo json_encode(['success' => false, 'message' => 'Comment not found or access denied']);
+    exit();
+}
+
+// Get total count of likes
+$countSql = "SELECT COUNT(*) as total FROM likes WHERE comment_id = ?";
+$totalResult = $Database->query($countSql, [$commentId]);
+
+if ($totalResult === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database error']);
+    exit();
+}
+
+$totalLikes = $totalResult[0]['total'];
+$totalPages = ceil($totalLikes / $limit);
+
+// Get likes with user information
+$likesSql = "
+    SELECT 
+        l.like_id,
+        l.created_at,
+        u.user_id,
+        u.username,
+        u.first_name,
+        u.last_name,
+        u.profile_picture
+    FROM likes l
+    INNER JOIN users u ON l.user_id = u.user_id
+    WHERE l.comment_id = ?
+    AND u.account_status = 'active'
+    ORDER BY l.created_at DESC
+    LIMIT ? OFFSET ?
+";
+
+$likes = $Database->query($likesSql, [$commentId, $limit, $offset]);
+
+if ($likes === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database error']);
+    exit();
+}
+
+// Format response
+$response = [
+    'success' => true,
+    'likes' => $likes,
+    'total_likes' => (int)$totalLikes,
+    'current_page' => $page,
+    'total_pages' => $totalPages
+];
+
+echo json_encode($response);

--- a/backend/src/api/posts/like_comment.php
+++ b/backend/src/api/posts/like_comment.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Like Comment API Endpoint
+ * 
+ * Adds a like to a comment
+ * Endpoint: POST /api/posts/like_comment
+ */
+
+// Set headers
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+// Handle preflight request
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    exit(0);
+}
+
+// Only allow POST requests
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed']);
+    exit();
+}
+
+// Require authentication
+$requireAuth = true;
+
+// Get database connection
+$Database = require_once dirname(dirname(dirname(__FILE__))) . '/db_handler/connection.php';
+
+// Include authentication middleware
+require_once dirname(dirname(__FILE__)) . '/auth/auth_middleware.php';
+
+// Get input data
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    $input = $_POST;
+}
+
+// Validate comment ID
+$commentId = isset($input['comment_id']) ? (int)$input['comment_id'] : null;
+if (!$commentId) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Comment ID is required']);
+    exit();
+}
+
+$userId = $authUser['user_id'];
+
+// Check if comment exists and user can view it (via post privacy)
+$checkSql = "
+    SELECT 
+        c.comment_id,
+        c.post_id,
+        p.user_id as post_user_id,
+        p.privacy_level
+    FROM comments c
+    INNER JOIN posts p ON c.post_id = p.post_id
+    INNER JOIN users u ON p.user_id = u.user_id
+    LEFT JOIN friendships f1 ON (f1.user_id_1 = ? AND f1.user_id_2 = p.user_id AND f1.status = 'accepted')
+    LEFT JOIN friendships f2 ON (f2.user_id_2 = ? AND f2.user_id_1 = p.user_id AND f2.status = 'accepted')
+    WHERE c.comment_id = ?
+    AND u.account_status = 'active'
+    AND (
+        p.user_id = ? OR  -- User's own posts
+        p.privacy_level = 'public' OR  -- Public posts
+        (p.privacy_level = 'friends' AND (f1.friendship_id IS NOT NULL OR f2.friendship_id IS NOT NULL))  -- Friends-only posts from accepted friends
+    )
+";
+
+$comment = $Database->query($checkSql, [$userId, $userId, $commentId, $userId]);
+
+if ($comment === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database error']);
+    exit();
+}
+
+if (empty($comment)) {
+    http_response_code(404);
+    echo json_encode(['success' => false, 'message' => 'Comment not found or access denied']);
+    exit();
+}
+
+// Check if user already liked this comment
+$existingLike = $Database->query(
+    "SELECT like_id FROM likes WHERE comment_id = ? AND user_id = ?",
+    [$commentId, $userId]
+);
+
+if ($existingLike === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database error']);
+    exit();
+}
+
+if (!empty($existingLike)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Comment already liked']);
+    exit();
+}
+
+// Add like
+$insertSql = "INSERT INTO likes (comment_id, user_id, created_at) VALUES (?, ?, ?)";
+$result = $Database->execute($insertSql, [$commentId, $userId, date('Y-m-d H:i:s')]);
+
+if ($result === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Failed to like comment']);
+    exit();
+}
+
+// Get updated like count
+$countSql = "SELECT COUNT(*) as likes_count FROM likes WHERE comment_id = ?";
+$countResult = $Database->query($countSql, [$commentId]);
+$likesCount = $countResult ? $countResult[0]['likes_count'] : 0;
+
+echo json_encode([
+    'success' => true,
+    'message' => 'Comment liked successfully',
+    'likes_count' => (int)$likesCount
+]);

--- a/backend/src/api/posts/unlike_comment.php
+++ b/backend/src/api/posts/unlike_comment.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Unlike Comment API Endpoint
+ * 
+ * Removes a like from a comment
+ * Endpoint: DELETE /api/posts/unlike_comment
+ */
+
+// Set headers
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: DELETE, POST');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+// Handle preflight request
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    exit(0);
+}
+
+// Allow DELETE and POST requests
+if (!in_array($_SERVER['REQUEST_METHOD'], ['DELETE', 'POST'])) {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed']);
+    exit();
+}
+
+// Require authentication
+$requireAuth = true;
+
+// Get database connection
+$Database = require_once dirname(dirname(dirname(__FILE__))) . '/db_handler/connection.php';
+
+// Include authentication middleware
+require_once dirname(dirname(__FILE__)) . '/auth/auth_middleware.php';
+
+// Get input data
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    $input = $_POST;
+}
+
+// Validate comment ID
+$commentId = isset($input['comment_id']) ? (int)$input['comment_id'] : null;
+if (!$commentId) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Comment ID is required']);
+    exit();
+}
+
+$userId = $authUser['user_id'];
+
+// Verify comment exists and check if the user can access it (through post privacy)
+$commentCheckSql = "SELECT c.comment_id, c.post_id, p.user_id as post_user_id, p.privacy_level 
+                    FROM comments c 
+                    JOIN posts p ON c.post_id = p.post_id 
+                    WHERE c.comment_id = ?";
+$commentResult = $Database->query($commentCheckSql, [$commentId]);
+
+if ($commentResult === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database error']);
+    exit();
+}
+
+if (empty($commentResult)) {
+    http_response_code(404);
+    echo json_encode(['success' => false, 'message' => 'Comment not found']);
+    exit();
+}
+
+$comment = $commentResult[0];
+
+// Check if user can access this comment based on post privacy
+if ($comment['privacy_level'] === 'private' && $comment['post_user_id'] != $userId) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Access denied']);
+    exit();
+}
+
+// Check if like exists
+$existingLike = $Database->query(
+    "SELECT like_id FROM likes WHERE comment_id = ? AND user_id = ?",
+    [$commentId, $userId]
+);
+
+if ($existingLike === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Database error']);
+    exit();
+}
+
+if (empty($existingLike)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Comment not liked yet']);
+    exit();
+}
+
+// Remove like
+$deleteSql = "DELETE FROM likes WHERE comment_id = ? AND user_id = ?";
+$result = $Database->execute($deleteSql, [$commentId, $userId]);
+
+if ($result === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Failed to unlike comment']);
+    exit();
+}
+
+// Get updated like count
+$countSql = "SELECT COUNT(*) as likes_count FROM likes WHERE comment_id = ?";
+$countResult = $Database->query($countSql, [$commentId]);
+$likesCount = $countResult ? $countResult[0]['likes_count'] : 0;
+
+echo json_encode([
+    'success' => true,
+    'message' => 'Comment unliked successfully',
+    'likes_count' => (int)$likesCount
+]);

--- a/tests/test_posts_media.php
+++ b/tests/test_posts_media.php
@@ -288,9 +288,7 @@
             </div>
             <button onclick="unlikePost()">Unlike Post</button>
             <div id="unlikeResponse" class="response"></div>
-        </div>
-
-        <!-- Get Post Likes -->
+        </div>        <!-- Get Post Likes -->
         <div class="container">
             <h3>Get Post Likes</h3>
             <div class="form-group">
@@ -303,6 +301,41 @@
             </div>
             <button onclick="getPostLikes()">Get Likes</button>
             <div id="getLikesResponse" class="response"></div>
+        </div>
+
+        <!-- Like Comment -->
+        <div class="container">
+            <h3>Like Comment</h3>
+            <div class="form-group">
+                <label for="likeCommentId">Comment ID:</label>
+                <input type="number" id="likeCommentId" placeholder="Enter comment ID to like">
+            </div>
+            <button onclick="likeComment()">Like Comment</button>
+            <div id="likeCommentResponse" class="response"></div>
+        </div>        <!-- Unlike Comment -->
+        <div class="container">
+            <h3>Unlike Comment</h3>
+            <div class="form-group">
+                <label for="unlikeCommentId">Comment ID:</label>
+                <input type="number" id="unlikeCommentId" placeholder="Enter comment ID to unlike">
+            </div>
+            <button onclick="unlikeComment()">Unlike Comment</button>
+            <div id="unlikeCommentResponse" class="response"></div>
+        </div>
+
+        <!-- Get Comment Likes -->
+        <div class="container">
+            <h3>Get Comment Likes</h3>
+            <div class="form-group">
+                <label for="getCommentLikesId">Comment ID:</label>
+                <input type="number" id="getCommentLikesId" placeholder="Enter comment ID">
+            </div>
+            <div class="form-group">
+                <label for="commentLikesPage">Page:</label>
+                <input type="number" id="commentLikesPage" value="1" min="1">
+            </div>
+            <button onclick="getCommentLikes()">Get Comment Likes</button>
+            <div id="getCommentLikesResponse" class="response"></div>
         </div>
     </div>
 
@@ -620,9 +653,7 @@
             
             const result = await makeRequest(API_BASE_URL + '/posts/unlike_post.php', 'DELETE', { post_id: parseInt(postId) });
             displayResponse('unlikeResponse', result.success ? result.data : result.error, !result.success);
-        }
-
-        async function getPostLikes() {
+        }        async function getPostLikes() {
             const postId = document.getElementById('getLikesPostId').value;
             const page = document.getElementById('likesPage').value;
             
@@ -633,6 +664,39 @@
             
             const result = await makeRequest(`${API_BASE_URL}/posts/get_post_likes.php?post_id=${postId}&page=${page}`);
             displayResponse('getLikesResponse', result.success ? result.data : result.error, !result.success);
+        }
+
+        async function likeComment() {
+            const commentId = document.getElementById('likeCommentId').value;
+            if (!commentId) {
+                displayResponse('likeCommentResponse', { error: 'Comment ID is required' }, true);
+                return;
+            }
+            
+            const result = await makeRequest(API_BASE_URL + '/posts/like_comment.php', 'POST', { comment_id: parseInt(commentId) });
+            displayResponse('likeCommentResponse', result.success ? result.data : result.error, !result.success);
+        }        async function unlikeComment() {
+            const commentId = document.getElementById('unlikeCommentId').value;
+            if (!commentId) {
+                displayResponse('unlikeCommentResponse', { error: 'Comment ID is required' }, true);
+                return;
+            }
+            
+            const result = await makeRequest(API_BASE_URL + '/posts/unlike_comment.php', 'DELETE', { comment_id: parseInt(commentId) });
+            displayResponse('unlikeCommentResponse', result.success ? result.data : result.error, !result.success);
+        }
+
+        async function getCommentLikes() {
+            const commentId = document.getElementById('getCommentLikesId').value;
+            const page = document.getElementById('commentLikesPage').value;
+            
+            if (!commentId) {
+                displayResponse('getCommentLikesResponse', { error: 'Comment ID is required' }, true);
+                return;
+            }
+            
+            const result = await makeRequest(`${API_BASE_URL}/posts/get_comment_likes.php?comment_id=${commentId}&page=${page}`);
+            displayResponse('getCommentLikesResponse', result.success ? result.data : result.error, !result.success);
         }
 
         // Comments API functions


### PR DESCRIPTION
- Implemented GET /api/posts/get_comment_likes to retrieve users who liked a comment, including pagination and access control.
- Created POST /api/posts/like_comment to allow users to like a comment, with checks for existing likes and access permissions.
- Developed DELETE /api/posts/unlike_comment to enable users to remove their likes from comments, ensuring proper access control and like existence checks.